### PR TITLE
Fixes #3 -- Reset Input Text

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -34,14 +34,20 @@ export default class Input extends Component {
     }
   }
 
-  render() {
-    const { style, ...props } = this.props;
+  resetInputText() {
+    this.refs.input.setNativeProps({ text: '' });
+    this.setState({
+      height: this.props.defaultHeight,
+    });
+  }
 
+  render() {
     return (
       <TextInput
-        style={[{ height:this.state.height }, style]}
+        ref="input"
         multiline
-        {...props}
+        {...this.props}
+        style={[{ height: this.state.height }, this.props.style]}
         onChange={this.handleChange}
       />);
   }


### PR DESCRIPTION
In this change we added `resetInputText` which can be called via `this.refs.inputRefName.resetInputText()` which will clear the input field via `setNativeProps` as well as reset the height of the input field

Also, onChange was moved to after the spread of `this.props` to hijack the onChange event -- until later
